### PR TITLE
fix: complete Stripe fee calculation interface migration and resolve …

### DIFF
--- a/components/register/Forms/attendee/LodgesForm.tsx
+++ b/components/register/Forms/attendee/LodgesForm.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import formSaveManager from '@/lib/formSaveManager';
 import { getFunctionTicketsService, FunctionTicketDefinition, FunctionPackage } from '@/lib/services/function-tickets-service';
 import { getEnvironmentConfig } from '@/lib/config/environment';
-import { calculateStripeFees, getFeeDisclaimer, getFeeModeFromEnv, getPlatformFeePercentage, getProcessingFeeLabel, isDomesticCard } from '@/lib/utils/stripe-fee-calculator';
+import { calculateStripeFees, STRIPE_RATES, getFeeDisclaimer, getFeeModeFromEnv, getPlatformFeePercentage, getProcessingFeeLabel, isDomesticCard } from '@/lib/utils/stripe-fee-calculator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 // Import form components
@@ -150,9 +150,7 @@ export const LodgesForm: React.FC<LodgesFormProps> = ({
     
     // Calculate Stripe fees
     const feeCalculation = calculateStripeFees(subtotal, {
-      isDomestic: true, // Default to domestic for Australian lodges
-      feeMode: getFeeModeFromEnv(),
-      platformFeePercentage: getPlatformFeePercentage()
+      isDomestic: true // Default to domestic for Australian lodges
     });
     
     setCalculatedPackageOrder({
@@ -160,7 +158,7 @@ export const LodgesForm: React.FC<LodgesFormProps> = ({
       totalTickets: packageCount * baseQuantity,
       totalPrice: subtotal,
       stripeFee: feeCalculation.stripeFee,
-      totalWithFees: feeCalculation.total
+      totalWithFees: feeCalculation.customerPayment
     });
   }, [packageCount, baseQuantity, packagePrice]);
 
@@ -554,9 +552,7 @@ export const LodgeFormSummary: React.FC = () => {
   // Calculate fees for the summary
   const subtotal = lodgeTicketOrder.tableCount * 1950;
   const feeCalculation = calculateStripeFees(subtotal, {
-    isDomestic: true, // Default to domestic for Australian lodges
-    feeMode: getFeeModeFromEnv(),
-    platformFeePercentage: getPlatformFeePercentage()
+    isDomestic: true // Default to domestic for Australian lodges
   });
 
   return (
@@ -614,7 +610,7 @@ export const LodgeFormSummary: React.FC = () => {
               <div className="flex justify-between items-center pt-2">
                 <span className="font-medium">Total Amount</span>
                 <span className="text-lg font-bold text-primary">
-                  ${feeCalculation.total.toLocaleString()}
+                  ${feeCalculation.customerPayment.toLocaleString()}
                 </span>
               </div>
             </div>

--- a/components/register/RegistrationWizard/Steps/LodgeRegistrationStep.tsx
+++ b/components/register/RegistrationWizard/Steps/LodgeRegistrationStep.tsx
@@ -14,7 +14,7 @@ import { Loader2, CreditCard, ShieldCheck, AlertCircle, ArrowLeft, Check } from 
 import { useRegistrationStore } from '@/lib/registrationStore';
 import { StripeBillingDetailsForClient } from '../payment/types';
 import { getFunctionTicketsService, FunctionPackage } from '@/lib/services/function-tickets-service';
-import { calculateStripeFees, getFeeModeFromEnv, getPlatformFeePercentage } from '@/lib/utils/stripe-fee-calculator';
+import { calculateStripeFees, STRIPE_RATES, getFeeModeFromEnv, getPlatformFeePercentage } from '@/lib/utils/stripe-fee-calculator';
 
 // Get Stripe publishable key
 const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!;
@@ -101,11 +101,9 @@ export const LodgeRegistrationStep: React.FC<LodgeRegistrationStepProps> = ({
   // Calculate total amount including Stripe fees
   const subtotal = lodgeTicketOrder ? lodgeTicketOrder.tableCount * packagePrice : 0;
   const feeCalculation = calculateStripeFees(subtotal, {
-    isDomestic: true, // Default to domestic for Australian lodges
-    feeMode: getFeeModeFromEnv(),
-    platformFeePercentage: getPlatformFeePercentage()
+    isDomestic: true // Default to domestic for Australian lodges
   });
-  const totalAmount = feeCalculation.total;
+  const totalAmount = feeCalculation.customerPayment;
 
   // Handle form completion
   const handleFormComplete = useCallback(() => {

--- a/components/register/RegistrationWizard/Steps/confirmation-step.tsx
+++ b/components/register/RegistrationWizard/Steps/confirmation-step.tsx
@@ -778,7 +778,7 @@ function ConfirmationStep({ confirmationNumber: propsConfirmationNumber, confirm
                     <Separator className="my-2" />
                     <div className="flex justify-between items-center">
                       <span className="font-bold text-lg">Total Paid:</span>
-                      <span className="font-bold text-lg">${calculateStripeFees(totalAmount).total.toFixed(2)}</span>
+                      <span className="font-bold text-lg">${calculateStripeFees(totalAmount).customerPayment.toFixed(2)}</span>
                     </div>
                   </div>
                 </CardContent>

--- a/components/register/RegistrationWizard/Steps/order-review-step.tsx
+++ b/components/register/RegistrationWizard/Steps/order-review-step.tsx
@@ -31,7 +31,7 @@ import { ticketService, EventTicket, TicketPackage } from '@/lib/api/ticketServi
 import { getFunctionTicketsService, type FunctionTicketDefinition, type FunctionPackage } from '@/lib/services/function-tickets-service';
 import { api } from '@/lib/api-logger';
 import { ValidationModal } from '@/components/ui/validation-modal';
-import { calculateStripeFees, getFeeDisclaimer, getFeeModeFromEnv, STRIPE_FEE_CONFIG, isDomesticCard, getProcessingFeeLabel, getPlatformFeePercentage } from '@/lib/utils/stripe-fee-calculator';
+import { calculateStripeFees, getFeeDisclaimer, getFeeModeFromEnv, STRIPE_RATES, isDomesticCard, getProcessingFeeLabel, getPlatformFeePercentage } from '@/lib/utils/stripe-fee-calculator';
 import { 
   Tooltip,
   TooltipContent,
@@ -241,10 +241,9 @@ function OrderReviewStep() {
   const subtotal = currentTickets.reduce((sum, ticket) => sum + ticket.price, 0)
   const feeCalculation = calculateStripeFees(subtotal, {
     isDomestic,
-    feeMode: getFeeModeFromEnv(),
     platformFeePercentage: getPlatformFeePercentage()
   })
-  const totalAmount = feeCalculation.total
+  const totalAmount = feeCalculation.customerPayment
   const totalTickets = currentTickets.length
 
   // Check if order is valid
@@ -512,8 +511,8 @@ function OrderReviewStep() {
                       <TooltipContent className="max-w-xs">
                         <p className="text-sm">{getFeeDisclaimer()}</p>
                         <div className="mt-2 text-xs space-y-1">
-                          <p>• Australian cards: {STRIPE_FEE_CONFIG.domestic.description}</p>
-                          <p>• International cards: {STRIPE_FEE_CONFIG.international.description}</p>
+                          <p>• Australian cards: {STRIPE_RATES.domestic.description}</p>
+                          <p>• International cards: {STRIPE_RATES.international.description}</p>
                         </div>
                         {!isDomestic && (
                           <p className="mt-2 text-xs font-medium">International fee applied based on billing country</p>

--- a/components/register/RegistrationWizard/Steps/payment-step.tsx
+++ b/components/register/RegistrationWizard/Steps/payment-step.tsx
@@ -23,7 +23,7 @@ import { CheckoutFormHandle } from "../payment/CheckoutForm";
 import { PaymentProcessing } from "../payment/PaymentProcessing";
 import { OneColumnStepLayout } from "../Layouts/OneColumnStepLayout";
 import { getFunctionTicketsService, type FunctionTicketDefinition, type FunctionPackage } from '@/lib/services/function-tickets-service';
-import { calculateStripeFees, formatFeeBreakdown, getFeeDisclaimer, getFeeModeFromEnv, getPlatformFeePercentage, isDomesticCard, getProcessingFeeLabel } from '@/lib/utils/stripe-fee-calculator';
+import { calculateStripeFees, STRIPE_RATES, formatFeeBreakdown, getFeeDisclaimer, getFeeModeFromEnv, getPlatformFeePercentage, isDomesticCard, getProcessingFeeLabel } from '@/lib/utils/stripe-fee-calculator';
 import { resolveTicketPrices, expandPackagesWithPricing, validateTicketPricing, type TicketWithPrice, type EventTicketRecord, type PackageRecord } from '@/lib/utils/ticket-price-resolver';
 import { Info } from "lucide-react";
 import { 
@@ -501,14 +501,12 @@ function PaymentStep(props: PaymentStepProps) {
     const isDomestic = isDomesticCard(billingCountry?.isoCode);
     
     return calculateStripeFees(subtotal, {
-      isDomestic,
-      feeMode: getFeeModeFromEnv(),
-      platformFeePercentage: getPlatformFeePercentage()
+      isDomestic
     });
   }, [subtotal, billingCountry]);
 
   // Total amount including fees
-  const totalAmount = feeCalculation.total;
+  const totalAmount = feeCalculation.customerPayment;
 
   // Handle payment method creation from CheckoutForm
   const handlePaymentMethodCreated = async (paymentMethodId: string, stripeBillingDetails: StripeBillingDetailsForClient) => {

--- a/components/register/RegistrationWizard/Steps/ticket-selection-step.tsx
+++ b/components/register/RegistrationWizard/Steps/ticket-selection-step.tsx
@@ -1631,7 +1631,7 @@ const TicketSelectionStep: React.FC = () => {
                                 )}
                                 <div className="flex justify-between items-center p-2 font-bold">
                                   <span>Total</span>
-                                  <span>${calculateStripeFees(getAttendeeTicketTotal(attendee.attendeeId)).total.toFixed(2)}</span>
+                                  <span>${calculateStripeFees(getAttendeeTicketTotal(attendee.attendeeId)).customerPayment.toFixed(2)}</span>
                                 </div>
                               </div>
                             </div>

--- a/components/register/RegistrationWizard/Summary/summary-data/ticket-summary-data.ts
+++ b/components/register/RegistrationWizard/Summary/summary-data/ticket-summary-data.ts
@@ -110,7 +110,6 @@ export function getTicketSummaryData({
     if (feeMode === 'pass_to_customer' && orderTotalAmount > 0) {
       const feeCalculation = calculateStripeFees(orderTotalAmount, {
         isDomestic: true, // Default to domestic for Australian customers
-        feeMode: feeMode,
         platformFeePercentage: 0 // This will be determined by the fee calculator
       });
       
@@ -121,7 +120,7 @@ export function getTicketSummaryData({
       
       orderItems.push({
         label: 'Total',
-        value: formatCurrency(feeCalculation.total),
+        value: formatCurrency(feeCalculation.customerPayment),
         isHighlight: true
       });
     } else {

--- a/components/register/RegistrationWizard/payment/OrderSummaryWithFees.tsx
+++ b/components/register/RegistrationWizard/payment/OrderSummaryWithFees.tsx
@@ -39,8 +39,7 @@ export const OrderSummaryWithFees: React.FC<OrderSummaryWithFeesProps> = ({
   const platformFeePercentage = getPlatformFeePercentage();
   const feeCalculation = calculateStripeFees(subtotalAmount, {
     isDomestic: true, // Default to domestic, could be enhanced to detect card type
-    platformFeePercentage,
-    feeMode
+    platformFeePercentage
   });
 
   return (
@@ -65,7 +64,7 @@ export const OrderSummaryWithFees: React.FC<OrderSummaryWithFeesProps> = ({
           <div className="space-y-2">
             <div className="flex justify-between text-sm">
               <span>Subtotal</span>
-              <span>${feeCalculation.subtotal.toFixed(2)}</span>
+              <span>${subtotalAmount.toFixed(2)}</span>
             </div>
             
             {showFees && feeMode === 'pass_to_customer' && (
@@ -94,7 +93,7 @@ export const OrderSummaryWithFees: React.FC<OrderSummaryWithFeesProps> = ({
           
           <div className="flex justify-between font-bold text-lg text-masonic-navy">
             <span>Amount Due:</span>
-            <span>${feeCalculation.total.toFixed(2)}</span>
+            <span>${feeCalculation.customerPayment.toFixed(2)}</span>
           </div>
           
           {showFees && feeMode === 'pass_to_customer' && (

--- a/lib/utils/__tests__/stripe-fee-calculator.test.ts
+++ b/lib/utils/__tests__/stripe-fee-calculator.test.ts
@@ -1,171 +1,399 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { 
   calculateStripeFees, 
-  calculateAbsorbedStripeFee,
+  calculateFeesWithGeolocation,
+  validateFeeCalculation,
   formatFeeBreakdown,
-  getFeeDisclaimer,
   getFeeExplanation,
-  getFeeModeFromEnv,
-  getPlatformFeePercentage
+  getFeeConfiguration,
+  getPlatformFeePercentage,
+  getPlatformFeeCap,
+  isDomesticCard,
+  getProcessingFeeLabel,
+  STRIPE_RATES
 } from '../stripe-fee-calculator';
 
-describe('Stripe Fee Calculator', () => {
-  describe('calculateStripeFees', () => {
-    it('calculates domestic card fees correctly in pass-to-customer mode', () => {
-      const result = calculateStripeFees(100, { 
-        isDomestic: true,
-        feeMode: 'pass_to_customer'
-      });
+// Mock environment variables
+const originalEnv = process.env;
+
+describe('Stripe Fee Calculator - Complete Overhaul', () => {
+  beforeEach(() => {
+    // Reset environment variables for each test
+    process.env = { ...originalEnv };
+    process.env.STRIPE_PLATFORM_FEE_PERCENTAGE = '0.02'; // 2%
+    process.env.STRIPE_PLATFORM_FEE_CAP = '20'; // $20 cap
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Basic Fee Calculation', () => {
+    it('calculates domestic fees correctly for small order', () => {
+      const result = calculateStripeFees(500, { isDomestic: true });
       
-      // For $100 with 1.7% + $0.30:
-      // total = (100 + 0.30) / (1 - 0.017) = 102.03
-      // stripeFee = 102.03 - 100 = 2.03
-      expect(result.subtotal).toBe(100);
-      expect(result.stripeFee).toBeCloseTo(2.03, 2);
-      expect(result.total).toBeCloseTo(102.03, 2);
-      expect(result.platformFee).toBe(0); // 0% platform fee
-    });
-
-    it('calculates international card fees correctly in pass-to-customer mode', () => {
-      const result = calculateStripeFees(100, { 
-        isDomestic: false,
-        feeMode: 'pass_to_customer'
-      });
+      // For $500 order:
+      // Platform fee = min($500 * 0.02, $20) = $10
+      // Customer payment = (($500 + $10) + $0.30) / (1 - 0.017) = $519.13
+      // Stripe fee = $519.13 * 0.017 + $0.30 = $9.13
+      // Processing fees = $519.13 - $500 = $19.13
       
-      // For $100 with 3.5% + $0.30:
-      // total = (100 + 0.30) / (1 - 0.035) = 103.94
-      // stripeFee = 103.94 - 100 = 3.94
-      expect(result.subtotal).toBe(100);
-      expect(result.stripeFee).toBeCloseTo(3.94, 2);
-      expect(result.total).toBeCloseTo(103.94, 2);
-      expect(result.platformFee).toBe(0); // 0% platform fee
-    });
-
-    it('calculates fees correctly in absorb mode', () => {
-      const result = calculateStripeFees(100, { 
-        isDomestic: true,
-        feeMode: 'absorb'
-      });
-      
-      // In absorb mode, customer pays subtotal only
-      expect(result.subtotal).toBe(100);
-      expect(result.stripeFee).toBeCloseTo(2.00, 2); // 1.7% of 100 + 0.30
-      expect(result.total).toBe(100); // Customer pays subtotal only
-    });
-
-    it('handles zero amount', () => {
-      const result = calculateStripeFees(0);
-      expect(result.subtotal).toBe(0);
-      expect(result.stripeFee).toBeCloseTo(0.31, 2); // Just the fixed fee
-      expect(result.total).toBeCloseTo(0.31, 2);
-    });
-
-    it('handles large amounts correctly', () => {
-      const result = calculateStripeFees(10000, { 
-        isDomestic: true,
-        feeMode: 'pass_to_customer'
-      });
-      
-      // For $10,000 with 1.7% + $0.30:
-      // total = (10000 + 0.30) / (1 - 0.017) = 10173.52
-      // stripeFee = 173.52
-      expect(result.subtotal).toBe(10000);
-      expect(result.stripeFee).toBeCloseTo(173.52, 2);
-      expect(result.total).toBeCloseTo(10173.52, 2);
-    });
-
-    it('rounds to 2 decimal places', () => {
-      const result = calculateStripeFees(33.33);
-      expect(result.subtotal).toBe(33.33);
-      expect(Number.isInteger(result.stripeFee * 100)).toBe(true);
-      expect(Number.isInteger(result.total * 100)).toBe(true);
-    });
-
-    it('uses custom platform fee percentage', () => {
-      const result = calculateStripeFees(100, { 
-        platformFeePercentage: 0.1 // 10%
-      });
+      expect(result.connectedAmount).toBe(500);
       expect(result.platformFee).toBe(10);
+      expect(result.customerPayment).toBeCloseTo(519.13, 2);
+      expect(result.stripeFee).toBeCloseTo(9.13, 2);
+      expect(result.processingFeesDisplay).toBeCloseTo(19.13, 2);
+      expect(result.isDomestic).toBe(true);
+      
+      // Validate the calculation
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
     });
-    
-    it('calculates $4 order correctly', () => {
-      const result = calculateStripeFees(4, { 
+
+    it('calculates domestic fees correctly for large order with platform fee cap', () => {
+      const result = calculateStripeFees(2300, { isDomestic: true });
+      
+      // For $2,300 order:
+      // Platform fee = min($2,300 * 0.02, $20) = $20 (capped)
+      // Customer payment = (($2,300 + $20) + $0.30) / (1 - 0.017) = $2,360.43
+      // Stripe fee = $2,360.43 * 0.017 + $0.30 = $40.43
+      // Processing fees = $2,360.43 - $2,300 = $60.43
+      
+      expect(result.connectedAmount).toBe(2300);
+      expect(result.platformFee).toBe(20); // Capped at $20
+      expect(result.customerPayment).toBeCloseTo(2360.43, 2);
+      expect(result.stripeFee).toBeCloseTo(40.43, 2);
+      expect(result.processingFeesDisplay).toBeCloseTo(60.43, 2);
+      expect(result.isDomestic).toBe(true);
+      
+      // Validate the calculation
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('calculates international fees correctly', () => {
+      const result = calculateStripeFees(2300, { isDomestic: false });
+      
+      // For $2,300 order with international rates (3.5%):
+      // Platform fee = min($2,300 * 0.02, $20) = $20 (capped)
+      // Customer payment = (($2,300 + $20) + $0.30) / (1 - 0.035) = $2,404.46
+      // Stripe fee = $2,404.46 * 0.035 + $0.30 = $84.46
+      // Processing fees = $2,404.46 - $2,300 = $104.46
+      
+      expect(result.connectedAmount).toBe(2300);
+      expect(result.platformFee).toBe(20); // Capped at $20
+      expect(result.customerPayment).toBeCloseTo(2404.46, 2);
+      expect(result.stripeFee).toBeCloseTo(84.46, 2);
+      expect(result.processingFeesDisplay).toBeCloseTo(104.46, 2);
+      expect(result.isDomestic).toBe(false);
+      
+      // Validate the calculation
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('handles very large orders where platform fee would exceed cap', () => {
+      const result = calculateStripeFees(5000, { isDomestic: true });
+      
+      // For $5,000 order:
+      // Platform fee = min($5,000 * 0.02, $20) = $20 (capped, not $100)
+      expect(result.connectedAmount).toBe(5000);
+      expect(result.platformFee).toBe(20); // Capped, not $100
+      
+      // Customer should pay less because platform fee is capped
+      expect(result.customerPayment).toBeLessThan(5000 + 100 + 50); // Much less than uncapped
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('handles edge case of zero amount', () => {
+      const result = calculateStripeFees(0, { isDomestic: true });
+      
+      expect(result.connectedAmount).toBe(0);
+      expect(result.platformFee).toBe(0);
+      expect(result.customerPayment).toBeCloseTo(0.31, 2); // Just the fixed fee
+      expect(result.stripeFee).toBeCloseTo(0.31, 2);
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+  });
+
+  describe('Platform Fee Capping', () => {
+    it('applies platform fee percentage for small amounts', () => {
+      const amounts = [100, 500, 750]; // All should be under $20 cap
+      
+      amounts.forEach(amount => {
+        const result = calculateStripeFees(amount, { isDomestic: true });
+        const expectedPlatformFee = amount * 0.02; // 2%
+        
+        expect(result.platformFee).toBeCloseTo(expectedPlatformFee, 2);
+        expect(result.platformFee).toBeLessThan(20); // Under cap
+      });
+    });
+
+    it('caps platform fee at configured maximum', () => {
+      const largeAmounts = [1500, 2300, 5000, 10000];
+      
+      largeAmounts.forEach(amount => {
+        const result = calculateStripeFees(amount, { isDomestic: true });
+        
+        expect(result.platformFee).toBe(20); // Always capped at $20
+        expect(result.platformFee).toBeLessThan(amount * 0.02); // Less than uncapped amount
+      });
+    });
+
+    it('respects custom platform fee cap', () => {
+      const result = calculateStripeFees(5000, { 
         isDomestic: true,
-        feeMode: 'pass_to_customer',
-        platformFeePercentage: 0
+        platformFeeCap: 50 // Custom $50 cap
       });
       
-      // For $4 with 1.7% + $0.30:
-      // total = (4 + 0.30) / (1 - 0.017) = 4.37
-      // stripeFee = 4.37 - 4 = 0.37
-      expect(result.subtotal).toBe(4);
-      expect(result.stripeFee).toBeCloseTo(0.37, 2);
-      expect(result.total).toBeCloseTo(4.37, 2);
-      expect(result.platformFee).toBe(0);
+      expect(result.platformFee).toBe(50); // Custom cap applied
     });
   });
 
-  describe('calculateAbsorbedStripeFee', () => {
-    it('calculates domestic absorbed fee correctly', () => {
-      const fee = calculateAbsorbedStripeFee(100, true);
-      expect(fee).toBe(2.00); // 1.7% of 100 + 0.30
-    });
-
-    it('calculates international absorbed fee correctly', () => {
-      const fee = calculateAbsorbedStripeFee(100, false);
-      expect(fee).toBe(3.80); // 3.5% of 100 + 0.30
-    });
-  });
-
-  describe('formatFeeBreakdown', () => {
-    it('formats fee breakdown correctly', () => {
-      const calculation = {
-        subtotal: 100,
-        stripeFee: 2.08,
-        platformFee: 5,
-        total: 102.08
-      };
+  describe('Geolocation-based Fee Determination', () => {
+    it('treats Australian customers as domestic', () => {
+      const result = calculateFeesWithGeolocation(1000, 'AU');
       
-      const breakdown = formatFeeBreakdown(calculation);
-      expect(breakdown).toEqual([
-        'Subtotal: $100.00',
-        'Processing Fee: $2.08',
-        'Total: $102.08'
-      ]);
+      expect(result.isDomestic).toBe(true);
+      expect(result.breakdown.stripePercentage).toBe(0.017);
+    });
+
+    it('treats non-Australian customers as international', () => {
+      const countries = ['US', 'GB', 'CA', 'NZ', 'DE'];
+      
+      countries.forEach(country => {
+        const result = calculateFeesWithGeolocation(1000, country);
+        
+        expect(result.isDomestic).toBe(false);
+        expect(result.breakdown.stripePercentage).toBe(0.035);
+      });
+    });
+
+    it('defaults to international when no country provided', () => {
+      const result = calculateFeesWithGeolocation(1000);
+      
+      expect(result.isDomestic).toBe(false); // Default to international for safety
+      expect(result.breakdown.stripePercentage).toBe(0.035);
+    });
+
+    it('handles country code case insensitivity', () => {
+      const variations = ['au', 'Au', 'aU', 'AU'];
+      
+      variations.forEach(country => {
+        const result = calculateFeesWithGeolocation(1000, country);
+        expect(result.isDomestic).toBe(true);
+      });
     });
   });
 
-  describe('getFeeDisclaimer', () => {
-    it('returns fee disclaimer text', () => {
-      const disclaimer = getFeeDisclaimer();
-      expect(disclaimer).toContain('processing fee');
-      expect(disclaimer).toContain('event organizer');
+  describe('Environment Variable Configuration', () => {
+    it('uses environment variables for platform fee configuration', () => {
+      process.env.STRIPE_PLATFORM_FEE_PERCENTAGE = '0.03'; // 3%
+      process.env.STRIPE_PLATFORM_FEE_CAP = '15'; // $15 cap
+      
+      const result = calculateStripeFees(1000, { isDomestic: true });
+      
+      expect(result.breakdown.platformFeePercentage).toBe(0.03);
+      expect(result.breakdown.platformFeeCap).toBe(15);
+      expect(result.platformFee).toBe(15); // min(1000 * 0.03, 15) = 15
+    });
+
+    it('uses default values when environment variables are missing', () => {
+      delete process.env.STRIPE_PLATFORM_FEE_PERCENTAGE;
+      delete process.env.STRIPE_PLATFORM_FEE_CAP;
+      
+      const result = calculateStripeFees(1000, { isDomestic: true });
+      
+      expect(result.breakdown.platformFeePercentage).toBe(0.02); // Default 2%
+      expect(result.breakdown.platformFeeCap).toBe(20); // Default $20
+    });
+
+    it('handles invalid environment variable values gracefully', () => {
+      process.env.STRIPE_PLATFORM_FEE_PERCENTAGE = 'invalid';
+      process.env.STRIPE_PLATFORM_FEE_CAP = 'also-invalid';
+      
+      const result = calculateStripeFees(1000, { isDomestic: true });
+      
+      // Should use defaults when parsing fails
+      expect(result.breakdown.platformFeePercentage).toBe(0.02);
+      expect(result.breakdown.platformFeeCap).toBe(20);
     });
   });
 
-  describe('getFeeExplanation', () => {
-    it('returns pass-to-customer explanation', () => {
-      const explanation = getFeeExplanation('pass_to_customer');
-      expect(explanation).toContain('fees are added');
-      expect(explanation).toContain('full ticket price');
+  describe('Fee Validation', () => {
+    it('validates correct fee calculations', () => {
+      const result = calculateStripeFees(1500, { isDomestic: true });
+      const validation = validateFeeCalculation(result);
+      
+      expect(validation.isValid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
     });
 
-    it('returns absorb explanation', () => {
-      const explanation = getFeeExplanation('absorb');
-      expect(explanation).toContain('final amount');
-      expect(explanation).toContain('covered by the event organizer');
+    it('detects calculation errors', () => {
+      const result = calculateStripeFees(1500, { isDomestic: true });
+      
+      // Manually corrupt the calculation
+      result.customerPayment = 999; // Incorrect value
+      
+      const validation = validateFeeCalculation(result);
+      
+      expect(validation.isValid).toBe(false);
+      expect(validation.errors.length).toBeGreaterThan(0);
+    });
+
+    it('validates platform fee cap enforcement', () => {
+      const result = calculateStripeFees(5000, { isDomestic: true });
+      
+      // Manually set platform fee above cap
+      result.platformFee = 150; // Way above $20 cap
+      
+      const validation = validateFeeCalculation(result);
+      
+      expect(validation.isValid).toBe(false);
+      expect(validation.errors.some(error => error.includes('exceeds cap'))).toBe(true);
     });
   });
 
-  describe('Environment configuration', () => {
-    it('getFeeModeFromEnv defaults to pass_to_customer', () => {
-      const mode = getFeeModeFromEnv();
-      expect(mode).toBe('pass_to_customer');
+  describe('UI Helper Functions', () => {
+    it('formats fee breakdown correctly', () => {
+      const result = calculateStripeFees(1000, { isDomestic: true });
+      const formatted = formatFeeBreakdown(result);
+      
+      expect(formatted.subtotal).toBe('$1000.00');
+      expect(formatted.total).toMatch(/^\$\d+\.\d{2}$/); // Proper currency format
+      expect(formatted.processingFees).toMatch(/^\$\d+\.\d{2}$/);
+      expect(formatted.feeType).toBe('Processing fees'); // Domestic
     });
 
-    it('getPlatformFeePercentage defaults to 0%', () => {
-      const percentage = getPlatformFeePercentage();
-      expect(percentage).toBe(0);
+    it('shows international fee label for international customers', () => {
+      const result = calculateStripeFees(1000, { isDomestic: false });
+      const formatted = formatFeeBreakdown(result);
+      
+      expect(formatted.feeType).toBe('International processing fees');
+    });
+
+    it('generates helpful fee explanations', () => {
+      const result = calculateStripeFees(1000, { isDomestic: true });
+      const explanation = getFeeExplanation(result);
+      
+      expect(explanation).toContain('platform fee');
+      expect(explanation).toContain('Stripe fees');
+      expect(explanation).toContain('domestic');
+      expect(explanation).toContain('event organizer receives the full ticket price');
+    });
+  });
+
+  describe('Utility Functions', () => {
+    it('correctly identifies domestic cards', () => {
+      expect(isDomesticCard('AU')).toBe(true);
+      expect(isDomesticCard('au')).toBe(true);
+      expect(isDomesticCard('US')).toBe(false);
+      expect(isDomesticCard('')).toBe(false);
+      expect(isDomesticCard(undefined)).toBe(false);
+    });
+
+    it('provides correct processing fee labels', () => {
+      expect(getProcessingFeeLabel(true)).toBe('Processing fees');
+      expect(getProcessingFeeLabel(false)).toBe('International processing fees');
+    });
+
+    it('provides fee configuration', () => {
+      const config = getFeeConfiguration();
+      
+      expect(config.platformFeePercentage).toBe(0.02);
+      expect(config.platformFeeCap).toBe(20);
+      expect(config.domesticRates).toEqual(STRIPE_RATES.domestic);
+      expect(config.internationalRates).toEqual(STRIPE_RATES.international);
+    });
+
+    it('exposes individual configuration getters', () => {
+      expect(getPlatformFeePercentage()).toBe(0.02);
+      expect(getPlatformFeeCap()).toBe(20);
+    });
+  });
+
+  describe('Real-world Examples', () => {
+    it('matches the PRD example: $2,300 domestic order', () => {
+      const result = calculateStripeFees(2300, { isDomestic: true });
+      
+      // From PRD: connected gets $2,300, platform fee capped at $20
+      expect(result.connectedAmount).toBe(2300);
+      expect(result.platformFee).toBe(20);
+      
+      // Customer should pay around $2,360 (corrected calculation)
+      expect(result.customerPayment).toBeCloseTo(2360.43, 1);
+      
+      // Processing fees should be around $60 (corrected calculation)
+      expect(result.processingFeesDisplay).toBeCloseTo(60.43, 1);
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('matches the PRD example: $2,300 international order', () => {
+      const result = calculateStripeFees(2300, { isDomestic: false });
+      
+      // From PRD: connected gets $2,300, platform fee capped at $20
+      expect(result.connectedAmount).toBe(2300);
+      expect(result.platformFee).toBe(20);
+      
+      // International customer should pay more (around $2,404 from PRD)
+      expect(result.customerPayment).toBeCloseTo(2404.45, 1);
+      
+      // Processing fees should be higher (~$104 from PRD)
+      expect(result.processingFeesDisplay).toBeCloseTo(104.45, 1);
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('handles the original problem case', () => {
+      // Original issue: connected account got $2,293.28 instead of $2,300
+      const result = calculateStripeFees(2300, { isDomestic: true });
+      
+      // With new calculation, connected account should get exactly $2,300
+      expect(result.connectedAmount).toBe(2300);
+      
+      // Verify the math works out correctly
+      const totalReceived = result.connectedAmount + result.platformFee + result.stripeFee;
+      expect(totalReceived).toBeCloseTo(result.customerPayment, 0.1);
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    it('handles very small amounts', () => {
+      const result = calculateStripeFees(1, { isDomestic: true });
+      
+      expect(result.connectedAmount).toBe(1);
+      expect(result.platformFee).toBeCloseTo(0.02, 2); // 2% of $1
+      expect(result.customerPayment).toBeGreaterThan(1);
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('handles maximum realistic amounts', () => {
+      const result = calculateStripeFees(100000, { isDomestic: true });
+      
+      expect(result.connectedAmount).toBe(100000);
+      expect(result.platformFee).toBe(20); // Still capped at $20
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('handles decimal amounts correctly', () => {
+      const result = calculateStripeFees(123.45, { isDomestic: true });
+      
+      expect(result.connectedAmount).toBe(123.45);
+      expect(result.platformFee).toBeCloseTo(2.47, 2); // 2% of $123.45
+      
+      const validation = validateFeeCalculation(result);
+      expect(validation.isValid).toBe(true);
     });
   });
 });


### PR DESCRIPTION
…build errors

This commit completes the migration to the new Stripe fee calculation system by:

## Core Changes
- Update all components to use new `StripeFeeCalculation` interface
- Replace deprecated `.total` property with `.customerPayment`
- Replace deprecated `.subtotal` with actual subtotal values
- Remove deprecated `feeMode` parameter from fee calculation calls
- Add required `STRIPE_RATES` import to all components

## Components Updated
- LodgesForm.tsx: Fix property access and remove deprecated parameters
- LodgeRegistrationStep.tsx: Update to new interface and remove platformFeePercentage param
- payment-step.tsx: Migrate to new interface, remove feeMode parameter
- OrderSummaryWithFees.tsx: Fix subtotal display to use actual subtotal value
- order-review-step.tsx: Update imports and property access
- ticket-selection-step.tsx: Fix total calculation property access
- confirmation-step.tsx: Update total display calculation
- ticket-summary-data.ts: Remove deprecated feeMode parameter

## API Integration
- create-payment-intent/route.ts: Implement transfer_data approach for correct fee handling
- Use calculateFeesWithGeolocation for proper fee calculation with user location
- Switch from application_fee_amount to transfer_data[amount] for exact connected account payments

## Test Coverage
- All 31 unit tests pass with new interface
- Fee calculation now ensures connected accounts receive exact intended amounts
- Fixed the core issue: connected accounts now get $2,300 instead of $2,293.28

🤖 Generated with [Claude Code](https://claude.ai/code)